### PR TITLE
Add position check for getItem method in base adapter class.

### DIFF
--- a/typedrecyclerviewadapter/src/main/java/com/halcyonmobile/typedrecyclerviewadapter/TypedRecyclerViewAdapter.kt
+++ b/typedrecyclerviewadapter/src/main/java/com/halcyonmobile/typedrecyclerviewadapter/TypedRecyclerViewAdapter.kt
@@ -61,7 +61,8 @@ abstract class TypedRecyclerViewAdapter<RecyclerItemType : RecyclerItem>(diffCal
         holder.binding.executePendingBindings()
     }
 
-    public override fun getItem(position: Int): RecyclerItemType? = super.getItem(position)
+    public override fun getItem(position: Int): RecyclerItemType? =
+        if (position in 0 until itemCount) super.getItem(position) else null
     // endregion Adapter methods
 
     /**


### PR DESCRIPTION
### Changes
Add proper position check for `getItem` method. This is required because if a custom implementation overrides the `getItemCount` method (ex. `PagingTypedRecyclerViewAdapter`), then the getItem may be called with an invalid position.